### PR TITLE
Remove dependency on cxx::Exception

### DIFF
--- a/examples/kj-rs-demo/src/promise-boilerplate.c++
+++ b/examples/kj-rs-demo/src/promise-boilerplate.c++
@@ -20,7 +20,7 @@ T unwrapNode(OwnPromiseNode node) {
 }
 
 extern "C" {
-  ::kj_rs::repr::PtrLen cxxbridge1$exception(const char *, std::size_t len) noexcept;
+  ::kj_rs::repr::PtrLen kjrs$exception(const char *, std::size_t len) noexcept;
 }
 
 template <typename T>
@@ -38,7 +38,7 @@ template <typename T>
     error.ptr = nullptr;
   })) {
     auto description = exception.getDescription();
-    error = cxxbridge1$exception(description.cStr(), description.size());
+    error = kjrs$exception(description.cStr(), description.size());
   }
   return error;
 }

--- a/examples/kj-rs-demo/src/promise_boilerplate.rs
+++ b/examples/kj-rs-demo/src/promise_boilerplate.rs
@@ -58,12 +58,12 @@ impl ::kj_rs::KjPromise for PromiseVoid {
         }
     }
     // https://github.com/dtolnay/cxx/blob/86cd652c06c5cb4c2e24d3ab555cf707b4ae0883/macro/src/expand.rs#L635
-    unsafe fn unwrap(node: OwnPromiseNode) -> std::result::Result<Self::Output, cxx::Exception> {
+    unsafe fn unwrap(node: OwnPromiseNode) -> std::result::Result<Self::Output, kj_rs::Exception> {
         unsafe extern "C" {
             fn own_promise_node_unwrap_void(
                 node: *mut OwnPromiseNode,
                 result: *mut (),
-            ) -> cxx::private::Result;
+            ) -> ::kj_rs::private::Result;
         }
         let mut node = ::cxx::core::mem::MaybeUninit::new(node);
         let mut ret = ::cxx::core::mem::MaybeUninit::<Self::Output>::uninit();
@@ -125,12 +125,12 @@ impl ::kj_rs::KjPromise for PromiseI32 {
         }
     }
     // https://github.com/dtolnay/cxx/blob/86cd652c06c5cb4c2e24d3ab555cf707b4ae0883/macro/src/expand.rs#L635
-    unsafe fn unwrap(node: OwnPromiseNode) -> std::result::Result<Self::Output, cxx::Exception> {
+    unsafe fn unwrap(node: OwnPromiseNode) -> std::result::Result<Self::Output, kj_rs::Exception> {
         unsafe extern "C" {
             fn own_promise_node_unwrap_i32(
                 node: *mut OwnPromiseNode,
                 result: *mut i32,
-            ) -> cxx::private::Result;
+            ) -> ::kj_rs::private::Result;
         }
         // `own_promise_node_unwrap_*()` consumes `node`, so we must avoid dropping it ourselves.
         let mut node = ::cxx::core::mem::MaybeUninit::new(node);

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -1,0 +1,30 @@
+// Copied from https://github.com/dtolnay/cxx/blob/d2727ef4a665cd07140b3662624a43a5cb56e99a/src/exception.rs
+//
+// The original `cxx` crate is dual-licensed under MIT and Apache 2.0 licenses. You will find a copy
+// of one of those licenses in the file named LICENSE in this repository's root directory.
+//
+// Slightly modified to fit into kj-rs.
+
+use core::fmt::{self, Display};
+use std::error::Error;
+
+/// Exception thrown from an `extern "C++"` function.
+#[derive(Debug)]
+pub struct Exception {
+    pub(crate) what: Box<str>,
+}
+
+impl Display for Exception {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&self.what)
+    }
+}
+
+impl Error for Exception {}
+
+impl Exception {
+    #[allow(missing_docs)]
+    pub fn what(&self) -> &str {
+        &self.what
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,15 @@ pub use crate::ffi::KjWaker;
 
 pub use kj_rs_macro::bridge_future;
 
+mod result;
+
+pub mod private {
+    pub use crate::result::Result;
+}
+
+mod exception;
+pub use exception::Exception;
+
 #[cxx::bridge(namespace = "kj_rs")]
 mod ffi {
     extern "Rust" {

--- a/src/promise.rs
+++ b/src/promise.rs
@@ -9,7 +9,7 @@ use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;
 
-type CxxResult<T> = std::result::Result<T, cxx::Exception>;
+type CxxResult<T> = std::result::Result<T, crate::Exception>;
 
 // The inner pointer is never read on Rust's side, so Rust thinks it's dead code.
 #[allow(dead_code)]

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,0 +1,65 @@
+// Copied from https://github.com/dtolnay/cxx/blob/d2727ef4a665cd07140b3662624a43a5cb56e99a/src/result.rs
+//
+// The original `cxx` crate is dual-licensed under MIT and Apache 2.0 licenses. You will find a copy
+// of one of those licenses in the file named LICENSE in this repository's root directory.
+//
+// Slightly modified to fit into kj-rs.
+
+#![allow(missing_docs)]
+
+use crate::exception::Exception;
+use core::fmt::Display;
+use core::ptr::{self, NonNull};
+use core::result::Result as StdResult;
+use core::slice;
+use core::str;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub(crate) struct PtrLen {
+    pub ptr: NonNull<u8>,
+    pub len: usize,
+}
+
+#[repr(C)]
+pub union Result {
+    err: PtrLen,
+    ok: *const u8, // null
+}
+
+impl Result {
+    pub unsafe fn exception(self) -> StdResult<(), Exception> {
+        unsafe {
+            if self.ok.is_null() {
+                Ok(())
+            } else {
+                let err = self.err;
+                let slice = slice::from_raw_parts_mut(err.ptr.as_ptr(), err.len);
+                let s = str::from_utf8_unchecked_mut(slice);
+                Err(Exception {
+                    what: Box::from_raw(s),
+                })
+            }
+        }
+    }
+}
+
+// =======================================================================================
+
+// Copied from https://github.com/dtolnay/cxx/blob/d2727ef4a665cd07140b3662624a43a5cb56e99a/src/symbols/exception.rs
+//
+// The original `cxx` crate is dual-licensed under MIT and Apache 2.0 licenses. You will find a copy
+// of one of those licenses in the file named LICENSE in this repository's root directory.
+//
+// Slightly modified to fit into kj-rs.
+
+#[export_name = "kjrs$exception"]
+unsafe extern "C" fn exception(ptr: *const u8, len: usize) -> PtrLen {
+    let slice = unsafe { std::slice::from_raw_parts(ptr, len) };
+    let string = String::from_utf8_lossy(slice);
+    let len = string.len();
+    let raw_str = Box::into_raw(string.into_owned().into_boxed_str());
+    let raw_u8 = raw_str.cast::<u8>();
+    let nonnull = unsafe { NonNull::new_unchecked(raw_u8) };
+    PtrLen { ptr: nonnull, len }
+}


### PR DESCRIPTION
Using cxx::Exception was convenient when originally figuring out how to return exceptions from C++ to Rust outside of a cxx-rs bridge interface. However, it depends on private details of cxx-rs' implementation which are intended for cxx-rs' own generated code.

It'd be nice if cxx-rs were written in such a way that we could share an Error / Exception type with it. For now, though, I'm copying code in, as it's simple enough.